### PR TITLE
fix bugs in combine.py

### DIFF
--- a/combine.py
+++ b/combine.py
@@ -139,9 +139,14 @@ def merge(dir):
     #for each parent
     dp1, dp2 = {}, {}
     for (array, ind, chrom) in input_data_sets(dir):
+        # skip run when there is no reads aligned
+        if not array: 
+            print ind, chrom, "no reads aligned"
+            continue
         print ind, chrom, len(array), "records"
         for x in array:
-            key = (ind, chrom, int(x['pos']))
+            # convert to float first to avoid the error when the number is using scientific notation
+            key = (ind, chrom, int(float(x['pos']))) 
             dp1[key] = x['par1']
             dp2[key] = x['par2']
 


### PR DESCRIPTION
- combine.py cannot handle x['pos'] in scientific note, such as '3e+05'. 
- combine.py cannot handle no reads aligned 



